### PR TITLE
Corrected notation for the piecewise function

### DIFF
--- a/BA4/NotesCours/Analyse-4/Lecture04/lecture04.tex
+++ b/BA4/NotesCours/Analyse-4/Lecture04/lecture04.tex
@@ -99,7 +99,7 @@
         e^{-\frac{1}{x}}, & \text{si } x > 0
     \end{functionbypart}
 
-    Il est possible de démontrer que cette fonction est de classe $C^\infty \left(\mathbb{R}\right)$. De plus, il est aussi possible de démontrer que, pour tout $n$, $f^{\left(n\right)} = 0$. Ainsi:
+    Il est possible de démontrer que cette fonction est de classe $C^\infty \left(\mathbb{R}\right)$. De plus, il est aussi possible de démontrer que, pour tout $n$,$f^{\left(n\right)}\left(0\right) = 0$. Ainsi:
     \[T_0\left(x\right) = \sum_{n=0}^{\infty} \frac{f^{\left(n\right)}\left(0\right)}{n!} x^n = 0\]
     
     Or, cela veut donc dire que, sur le point $x_0 = 0$, il n'est pas possible de trouver de rayon de convergence; il n'existe aucun $\epsilon > 0$ telle que cette fonction est égale à sa série de Taylor autour de 0. $f$ n'est donc pas analytique en $x_0 = 0$.

--- a/BA4/NotesCours/Analyse-4/Lecture04/lecture04.tex
+++ b/BA4/NotesCours/Analyse-4/Lecture04/lecture04.tex
@@ -99,7 +99,7 @@
         e^{-\frac{1}{x}}, & \text{si } x > 0
     \end{functionbypart}
 
-    Il est possible de démontrer que cette fonction est de classe $C^\infty \left(\mathbb{R}\right)$. De plus, il est aussi possible de démontrer que, pour tout $n$,$f^{\left(n\right)}\left(0\right) = 0$. Ainsi:
+    Il est possible de démontrer que cette fonction est de classe $C^\infty \left(\mathbb{R}\right)$. De plus, il est aussi possible de démontrer que, pour tout $n$, $f^{\left(n\right)}\left(0\right) = 0$. Ainsi:
     \[T_0\left(x\right) = \sum_{n=0}^{\infty} \frac{f^{\left(n\right)}\left(0\right)}{n!} x^n = 0\]
     
     Or, cela veut donc dire que, sur le point $x_0 = 0$, il n'est pas possible de trouver de rayon de convergence; il n'existe aucun $\epsilon > 0$ telle que cette fonction est égale à sa série de Taylor autour de 0. $f$ n'est donc pas analytique en $x_0 = 0$.


### PR DESCRIPTION
[`BA4/NotesCours/Analyse-4/Lecture04/lecture04.tex`](diffhunk://#diff-b7d6312fdc7c93d23c236d809380461c49e79aca18c6fbd52276940b5c15a66bL102-R102): Modified the text to specify that the derivatives of the function evaluated at zero are zero, i.e., `f^{\left(n\right)}\left(0\right) = 0`.